### PR TITLE
Add sed as a parameter variable in order to be able to specify the sed version that must be used.

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -14,3 +14,7 @@
 
 # create new private key for each csr (yes|no)
 #PRIVATE_KEY_RENEW=no
+
+# GNU sed program to use - use gsed on some plateforms
+#SED=sed
+

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -12,6 +12,7 @@ RENEW_DAYS="14"
 KEYSIZE="4096"
 WELLKNOWN=".acme-challenges"
 PRIVATE_KEY_RENEW=no
+SED=sed
 
 if [[ -e "config.sh" ]]; then
   . ./config.sh
@@ -25,7 +26,7 @@ anti_newline() {
 
 urlbase64() {
   # urlbase64: base64 encoded string with '+' replaced with '-' and '/' replaced with '_'
-  openssl base64 -e | anti_newline | sed -r 's/=*$//g' | tr '+/' '-_'
+  openssl base64 -e | anti_newline | ${SED} -r 's/=*$//g' | tr '+/' '-_'
 }
 
 hex2bin() {
@@ -123,7 +124,7 @@ sign_domain() {
   for altname in $altnames; do
     SAN+="DNS:${altname}, "
   done
-  SAN="$(printf '%s' "${SAN}" | sed 's/,\s*$//g')"
+  SAN="$(printf '%s' "${SAN}" | ${SED} 's/,\s*$//g')"
   echo "  + Generating signing request..."
   openssl req -new -sha256 -key "certs/${domain}/privkey.pem" -out "certs/${domain}/cert.csr" -subj "/CN=${domain}/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=%s" "${SAN}")) > /dev/null
 
@@ -133,8 +134,8 @@ sign_domain() {
     echo "  + Requesting challenge for ${altname}..."
     response="$(signed_request "${CA}/acme/new-authz" '{"resource": "new-authz", "identifier": {"type": "dns", "value": "'"${altname}"'"}}')"
 
-    challenge_token="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | sed 's/{/\n{/g' | grep 'http-01' | grep -Eo '"token":\s*"[^"]*"' | cut -d'"' -f4 | sed 's/[^A-Za-z0-9_\-]/_/g')"
-    challenge_uri="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | sed 's/{/\n{/g' | grep 'http-01' | grep -Eo '"uri":\s*"[^"]*"' | cut -d'"' -f4)"
+    challenge_token="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | ${SED} 's/{/\n{/g' | grep 'http-01' | grep -Eo '"token":\s*"[^"]*"' | cut -d'"' -f4 | sed 's/[^A-Za-z0-9_\-]/_/g')"
+    challenge_uri="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | ${SED} 's/{/\n{/g' | grep 'http-01' | grep -Eo '"uri":\s*"[^"]*"' | cut -d'"' -f4)"
 
     if [[ -z "${challenge_token}" ]] || [[ -z "${challenge_uri}" ]]; then
       echo "  + Error: Can't retrieve challenges (${response})"
@@ -215,7 +216,7 @@ if [[ ! -e "${WELLKNOWN}" ]]; then
 fi
 
 # Generate certificates for all domains found in domain.txt. Check if existing certificate are about to expire
-<domains.txt sed 's/^\s*//g;s/\s*$//g' | grep -v '^#' | grep -v '^$' | while read -r line; do
+<domains.txt ${SED} 's/^\s*//g;s/\s*$//g' | grep -v '^#' | grep -v '^$' | while read -r line; do
   domain="$(echo $line | cut -d' ' -f1)"
   if [[ -e "certs/${domain}/cert.pem" ]]; then
     echo -n "Found existing cert for ${domain}. Expire date ..."


### PR DESCRIPTION
Add sed as a parameter variable in order to be able to specify the sed version that must be used.

The goal is to be able to specify another sed program as the one to be used must be the GNU sed (-r parameter is used).

For instance default sed program on OS X is not supporting this parameter and launching lets encrypt.sh is displaying following error:

sed: illegal option -- r
usage: sed script [-Ealn] [-i extension] [file ...]
       sed [-Ealn] [-i extension] [-e script] ... [-f script_file] ... [file ...]

GNU sed can be installed from macport and its name is gsed. 

So a simple SED=gsed in config.sh file is resolving this issue. 

