### PR TITLE
Openssl.cnf parameter

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -14,3 +14,7 @@
 
 # create new private key for each csr (yes|no)
 #PRIVATE_KEY_RENEW=no
+
+# GNU sed program to use - use gsed on some plateforms
+#SED=sed
+

--- a/config.sh.example
+++ b/config.sh.example
@@ -18,3 +18,11 @@
 # GNU sed program to use - use gsed on some plateforms
 #SED=sed
 
+# opennsl.cnf file
+#OPENSSLCNF=/etc/ssl/openssl.cnf
+#OPENSSLCNF=/System/Library/OpenSSL/openssl.cnf
+#OPENSSLCNF=/etc/pki/tls/openssl.cnf
+#OPENSSLCNF=/usr/lib/ssl/openssl.cnf
+#OPENSSLCNF=/usr/local/ssl/openssl.cnf
+
+

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -13,6 +13,7 @@ KEYSIZE="4096"
 WELLKNOWN=".acme-challenges"
 PRIVATE_KEY_RENEW=no
 SED=sed
+OPENSSLCNF=/etc/ssl/openssl.cnf
 
 if [[ -e "config.sh" ]]; then
   . ./config.sh
@@ -126,7 +127,7 @@ sign_domain() {
   done
   SAN="$(printf '%s' "${SAN}" | ${SED} 's/,\s*$//g')"
   echo "  + Generating signing request..."
-  openssl req -new -sha256 -key "certs/${domain}/privkey.pem" -out "certs/${domain}/cert.csr" -subj "/CN=${domain}/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=%s" "${SAN}")) > /dev/null
+  openssl req -new -sha256 -key "certs/${domain}/privkey.pem" -out "certs/${domain}/cert.csr" -subj "/CN=${domain}/" -reqexts SAN -config <(cat ${OPENSSLCNF} <(printf "[SAN]\nsubjectAltName=%s" "${SAN}")) > /dev/null
 
   # Request and respond to challenges
   for altname in $altnames; do

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -12,6 +12,7 @@ RENEW_DAYS="14"
 KEYSIZE="4096"
 WELLKNOWN=".acme-challenges"
 PRIVATE_KEY_RENEW=no
+SED=sed
 
 if [[ -e "config.sh" ]]; then
   . ./config.sh
@@ -25,7 +26,7 @@ anti_newline() {
 
 urlbase64() {
   # urlbase64: base64 encoded string with '+' replaced with '-' and '/' replaced with '_'
-  openssl base64 -e | anti_newline | sed -r 's/=*$//g' | tr '+/' '-_'
+  openssl base64 -e | anti_newline | ${SED} -r 's/=*$//g' | tr '+/' '-_'
 }
 
 hex2bin() {
@@ -123,7 +124,7 @@ sign_domain() {
   for altname in $altnames; do
     SAN+="DNS:${altname}, "
   done
-  SAN="$(printf '%s' "${SAN}" | sed 's/,\s*$//g')"
+  SAN="$(printf '%s' "${SAN}" | ${SED} 's/,\s*$//g')"
   echo "  + Generating signing request..."
   openssl req -new -sha256 -key "certs/${domain}/privkey.pem" -out "certs/${domain}/cert.csr" -subj "/CN=${domain}/" -reqexts SAN -config <(cat /etc/ssl/openssl.cnf <(printf "[SAN]\nsubjectAltName=%s" "${SAN}")) > /dev/null
 
@@ -133,8 +134,8 @@ sign_domain() {
     echo "  + Requesting challenge for ${altname}..."
     response="$(signed_request "${CA}/acme/new-authz" '{"resource": "new-authz", "identifier": {"type": "dns", "value": "'"${altname}"'"}}')"
 
-    challenge_token="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | sed 's/{/\n{/g' | grep 'http-01' | grep -Eo '"token":\s*"[^"]*"' | cut -d'"' -f4 | sed 's/[^A-Za-z0-9_\-]/_/g')"
-    challenge_uri="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | sed 's/{/\n{/g' | grep 'http-01' | grep -Eo '"uri":\s*"[^"]*"' | cut -d'"' -f4)"
+    challenge_token="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | ${SED} 's/{/\n{/g' | grep 'http-01' | grep -Eo '"token":\s*"[^"]*"' | cut -d'"' -f4 | sed 's/[^A-Za-z0-9_\-]/_/g')"
+    challenge_uri="$(printf '%s\n' "${response}" | grep -Eo '"challenges":[^\[]*\[[^]]*]' | ${SED} 's/{/\n{/g' | grep 'http-01' | grep -Eo '"uri":\s*"[^"]*"' | cut -d'"' -f4)"
 
     if [[ -z "${challenge_token}" ]] || [[ -z "${challenge_uri}" ]]; then
       echo "  + Error: Can't retrieve challenges (${response})"
@@ -215,7 +216,7 @@ if [[ ! -e "${WELLKNOWN}" ]]; then
 fi
 
 # Generate certificates for all domains found in domain.txt. Check if existing certificate are about to expire
-<domains.txt sed 's/^\s*//g;s/\s*$//g' | grep -v '^#' | grep -v '^$' | while read -r line; do
+<domains.txt ${SED} 's/^\s*//g;s/\s*$//g' | grep -v '^#' | grep -v '^$' | while read -r line; do
   domain="$(echo $line | cut -d' ' -f1)"
   if [[ -e "certs/${domain}/cert.pem" ]]; then
     echo -n "Found existing cert for ${domain}. Expire date ..."


### PR DESCRIPTION
add openssl.cnf as a parameter. 

Default path is not always /etc/ssl/openssl.cnf

It could be some of following:
* OPENSSLCNF=/System/Library/OpenSSL/openssl.cnf
* OPENSSLCNF=/etc/pki/tls/openssl.cnf
* OPENSSLCNF=/usr/lib/ssl/openssl.cnf
* OPENSSLCNF=/usr/local/ssl/openssl.cnf

Goal is to avoid error like:
```

Signing domainwww.example.org (www.example.org)...
  + Generating signing request...
cat: /etc/ssl/openssl.cnf: No such file or directory
unable to find 'distinguished_name' in config
problems making Certificate Request
140735281533008:error:0E06D06C:configuration file routines:NCONF_get_string:no value:conf_lib.c:324:group=req name=distinguished_name
```
