### PR TITLE
add HOOK_POST_CREATION

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -17,3 +17,10 @@
 
 # create new private key for each csr (yes|no)
 #PRIVATE_KEY_RENEW=no
+
+# program called after creating the certs arguments: status path/to/token token
+# path/to/fullchain path/to/privkey path/to/cert ; can be used to e.g. clean 
+# the challenge or to upload certs if this script doesn't run on the 
+# webserver
+#HOOK_POST_CREATION=
+

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -16,6 +16,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BASEDIR="${SCRIPTDIR}"
 OPENSSL_CNF="$(openssl version -d | cut -d'"' -f2)/openssl.cnf"
 ROOTCERT="lets-encrypt-x1-cross-signed.pem"
+HOOK_POST_CREATION=
 
 # If exists load config from same directory as this script
 if [[ -e "${BASEDIR}/config.sh" ]]; then
@@ -194,6 +195,12 @@ sign_domain() {
       echo " + Challenge is valid!"
     else
       echo " + Challenge is invalid! (returned: ${status})"
+	  
+      # Wait for hook script to clean the challenge if used
+      if [ -n "${HOOK_POST_CREATION}" ]; then
+        ${HOOK_POST_CREATION} "invalid" "${WELLKNOWN}/${challenge_token}" "${keyauth}" 
+      fi
+      
       exit 1
     fi
 
@@ -229,6 +236,12 @@ sign_domain() {
 
   rm -f "${BASEDIR}/certs/${domain}/cert.pem"
   ln -s "cert-${timestamp}.pem" "${BASEDIR}/certs/${domain}/cert.pem"
+
+  # Wait for hook script to clean the challenge and to deploy cert if used
+  if [ -n "${HOOK_POST_CREATION}" ]; then
+      ${HOOK_POST_CREATION} "valid" "${WELLKNOWN}/${challenge_token}" "${keyauth}" "${BASEDIR}/certs/${domain}/fullchain.pem" "${BASEDIR}/certs/${domain}/privkey.pem" "${BASEDIR}/certs/${domain}/cert.pem" 
+  fi
+
 
   echo " + Done!"
 }


### PR DESCRIPTION
Add a hook after creation of certificate in order to be able to clean challenge on remote servers and to upload created certs.

To replace pull request #24 

Add status parameter and trigger it when challenge failed to answer to @germeier 

