### PR TITLE
Hook for deploying certs via ssh

### DIFF
--- a/ssh_filter_letsencrypt.sh
+++ b/ssh_filter_letsencrypt.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#
+# Use on webserver, in conjunction with ssh_hook.sh, either as
+# "ForceCommand" in "sshd_config", or in "authorized_keys".
+#
+# Example line in "authorized_keys" file:
+#
+#   from="192.168.0.42",command="/home/letsencrypt/ssh_filter_letsencrypt.sh --log",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding <pubkey>...
+#
+
+declare -A challenge_dir key_file cert_file fullchain_file
+
+### config section ###
+
+challenge_dir[example.org]="/var/www/www.example.org/htdocs/.well-known/acme-challenge"
+challenge_dir[www.example.org]="/var/www/www.example.org/htdocs/.well-known/acme-challenge"
+
+key_file[example.org]="/etc/ssl/apache2/example.org/privkey.pem"
+cert_file[example.org]="/etc/ssl/apache2/example.org/cert.pem"
+fullchain_file[example.org]="/etc/ssl/apache2/example.org/fullchain.pem"
+
+### end config section ###
+
+
+set -e
+set -u
+set -o pipefail
+
+enable_log=
+
+log_cmd()
+{
+  if [[ -n "$enable_log" ]]; then
+    logger -p $1 -t ssh_filter_letsencrypt.sh "$2 (Name: ${LOGNAME:-<unknown>}; Remote: ${SSH_CLIENT:-<unknown>})${3:+: $3}"
+  fi
+}
+
+reject_and_die()
+{
+  local reason=$1
+  log_cmd "auth.err" "REJECT" "$reason"
+  echo "ERROR: ssh_filter_letsencrypt.sh: ssh command rejected: $reason" >&2
+  exit 1
+}
+
+
+trap 'reject_and_die "script error"' EXIT
+
+while [[ "$#" -ge 1 ]]; do
+  key="$1"
+  case $key in
+    -l|--log)
+      enable_log=1
+      ;;
+    *)
+      echo "ERROR: ssh_filter_letsencrypt.sh: failed to parse command line option: $key" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+
+case "$SSH_ORIGINAL_COMMAND" in
+  *\$*)     reject_and_die "unsafe character"     ;;
+  *\&*)     reject_and_die "unsafe character"     ;;
+  *\(*)     reject_and_die "unsafe character"     ;;
+  *\{*)     reject_and_die "unsafe character"     ;;
+  *\;*)     reject_and_die "unsafe character"     ;;
+  *\<*)     reject_and_die "unsafe character"     ;;
+  *\>*)     reject_and_die "unsafe character"     ;;
+  *\`*)     reject_and_die "unsafe character"     ;;
+  *\|*)     reject_and_die "unsafe character"     ;;
+  *\.\./*)  reject_and_die "directory traversal"  ;;
+esac
+
+
+array=($SSH_ORIGINAL_COMMAND)
+command=${array[0]}
+
+case $command in
+  deploy_challenge)
+    altname=${array[1]}
+    challenge_token=${array[2]}
+    keyauth=${array[3]}
+    outdir=${challenge_dir[$altname]}
+    echo -n "$keyauth" > ${outdir}/${challenge_token}
+    ;;
+  clean_challenge)
+    altname=${array[1]}
+    challenge_token=${array[2]}
+    keyauth=${array[3]}
+    outdir=${challenge_dir[$altname]}
+    rm ${outdir}/${challenge_token}
+    ;;
+  deploy_privkey)
+    domain=${array[1]}
+    outfile=${key_file[$domain]}
+    cat > ${outfile}
+    ;;
+  deploy_cert)
+    domain=${array[1]}
+    outfile=${cert_file[$domain]}
+    cat > ${outfile}
+    ;;
+  deploy_fullchain)
+    domain=${array[1]}
+    outfile=${fullchain_file[$domain]}
+    cat > ${outfile}
+    ;;
+  *)
+    reject_and_die "illegal command"
+    ;;
+esac
+
+log_cmd "auth.info" "$command"
+
+echo " * ssh_filter_letsencrypt.sh: ${command}: success"
+
+trap - EXIT
+exit 0

--- a/ssh_hook.sh
+++ b/ssh_hook.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# Deploy letsencrypt certificates via ssh.
+#
+# Use in conjunction with "ssh_filter_letsencrypt.sh".
+#
+
+set -e
+set -u
+set -o pipefail
+
+declare -A rsh
+
+### config section ###
+
+rsh[example.org]="ssh -i /etc/ssh/id_rsa.letsencrypt letsencrypt@example.org"
+rsh[www.example.org]="ssh -i /etc/ssh/id_rsa.letsencrypt letsencrypt@example.org"
+
+### end config section ###
+
+
+command=$1
+echo " * ssh_hook.sh: $command"
+
+case $command in
+  deploy_challenge|clean_challenge)
+    altname=$2
+    ${rsh[$altname]} $@
+    ;;
+  deploy_cert)
+    domain=$2
+    privkey=$3
+    cert=$4
+    fullchain=$5
+    cat $privkey | ${rsh[$domain]} deploy_privkey $domain
+    cat $cert | ${rsh[$domain]} deploy_cert $domain
+    cat $fullchain | ${rsh[$domain]} deploy_fullchain $domain
+    ;;
+  *)
+    echo "illegal command" >&2
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
First of all, thanks for this wonderful script!

I implemented a hook for deploying the certificates remotely via ssh, in two parts:

- **ssh_hook.sh**:  the HOOK to define in config.sh.
- **ssh_filter_letsencrypt.sh**: SSH ForceCommand to define in sshd_config (or command="..." in authorized_keys) on the remote webserver.

If you like this patch, I will gladly write some documentation for it (something like the documentation of the ssh script I wrote for btrbk: https://github.com/digint/btrbk#setting-up-ssh).

Maybe it would be good to introduce some "contrib" folder for scripts like these, let me know what you think!