### PR TITLE
fix logic if private key is specified via command line option

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -22,14 +22,14 @@
 # Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: $SCRIPTDIR/.acme-challenges)
 #WELLKNOWN="${SCRIPTDIR}/.acme-challenges"
 
+# Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
+#BASEDIR=$SCRIPTDIR
+
 # Location of private account key
 #PRIVATE_KEY=${BASEDIR}/private_key.pem
 
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"
-
-# Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
-#BASEDIR=$SCRIPTDIR
 
 # Path to openssl config file (default: <unset> - tries to figure out system default)
 #OPENSSL_CNF=

--- a/config.sh.example
+++ b/config.sh.example
@@ -22,6 +22,9 @@
 # Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: $SCRIPTDIR/.acme-challenges)
 #WELLKNOWN="${SCRIPTDIR}/.acme-challenges"
 
+# Location of private account key
+#PRIVATE_KEY=${BASEDIR}/private_key.pem
+
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"
 


### PR DESCRIPTION
- move BASEDIR further up in the config file
- make private key a config option
- fix logic if private key is specified via command line option
- start using PARAM_* for parameters provided at the command line