### PR TITLE
Don't use SCRIPTDIR

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -19,14 +19,14 @@
 # Path to license agreement (default: https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf)
 #LICENSE="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
 
-# Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: $SCRIPTDIR/.acme-challenges)
-#WELLKNOWN="${SCRIPTDIR}/.acme-challenges"
-
 # Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
 #BASEDIR=$SCRIPTDIR
 
-# Location of private account key
-#PRIVATE_KEY=${BASEDIR}/private_key.pem
+# Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: $BASEDIR/.acme-challenges)
+#WELLKNOWN="${BASEDIR}/.acme-challenges"
+
+# Location of private account key (default: $BASEDIR/private_key.pem)
+#PRIVATE_KEY="${BASEDIR}/private_key.pem"
 
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -127,8 +127,6 @@ init_system() {
 
   if [[ -e "${BASEDIR}/domains.txt" ]]; then
     DOMAINS_TXT="${BASEDIR}/domains.txt"
-  elif [[ -e "${SCRIPTDIR}/domains.txt" ]]; then
-    DOMAINS_TXT="${SCRIPTDIR}/domains.txt"
   else
     echo "You have to create a domains.txt file listing the domains you want certificates for. Have a look at domains.txt.example."
     exit 1
@@ -350,14 +348,10 @@ sign_domain() {
   _openssl x509 -text < "${crt_path}"
 
   # Create fullchain.pem
-  if [[ -e "${BASEDIR}/certs/${ROOTCERT}" ]] || [[ -e "${SCRIPTDIR}/certs/${ROOTCERT}" ]]; then
+  if [[ -e "${BASEDIR}/certs/${ROOTCERT}" ]]; then
     echo " + Creating fullchain.pem..."
     cat "${crt_path}" > "${BASEDIR}/certs/${domain}/fullchain-${timestamp}.pem"
-    if [[ -e "${BASEDIR}/certs/${ROOTCERT}" ]]; then
-      cat "${BASEDIR}/certs/${ROOTCERT}" >> "${BASEDIR}/certs/${domain}/fullchain-${timestamp}.pem"
-    else
-      cat "${SCRIPTDIR}/certs/${ROOTCERT}" >> "${BASEDIR}/certs/${domain}/fullchain-${timestamp}.pem"
-    fi
+    cat "${BASEDIR}/certs/${ROOTCERT}" >> "${BASEDIR}/certs/${domain}/fullchain-${timestamp}.pem"
     ln -sf "fullchain-${timestamp}.pem" "${BASEDIR}/certs/${domain}/fullchain.pem"
   fi
 


### PR DESCRIPTION
When deploying your script, I found that you are using SCRIPTDIR as fall-back directory. This is very error-prone, and completely unnecessary (as BASEDIR defaults to SCRIPTDIR).

For security sake, NOTHING should be relative to SCRIPTDIR, not even the config.sh file location (I did not patch this as it would change the basic bahaviour).

Some further suggestions:
- use only one default location for config.sh (e.g. /etc/letsencrypt.sh/config.sh), as an attacker can do nasty stuff if he gets access on any of the config locations
- don't use default config if config.sh is not found, as this does most probably break things for most users
