### PR TITLE
bugfix: keep configured PRIVATE_KEY

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -119,7 +119,6 @@ init_system() {
     fi
   else
     # Check if private account key exists, if it doesn't exist yet generate a new one (rsa key)
-    PRIVATE_KEY="${BASEDIR}/private_key.pem"
     if [[ ! -e "${PRIVATE_KEY}" ]]; then
       echo "+ Generating account key..."
       _openssl genrsa -out "${PRIVATE_KEY}" "${KEYSIZE}"


### PR DESCRIPTION
When overriding PRIVATE_KEY in config.sh, letsencrypt.sh erroneously changes it back to "${BASEDIR}/private_key.pem"