### PR TITLE
two revoke fixes

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -452,8 +452,16 @@ command_sign_domains() {
 # Description: Revoke specified certificate
 command_revoke() {
   cert="${1}"
+  if [[ -L "${cert}" ]]; then
+    # follow symlink and use real certificate name (so we move the real file and not the symlink at the end)
+    cert="$(dirname "$cert")/$(readlink -n "$cert")"
+  fi
+  if [[ ! -f "${cert}" ]]; then
+    echo "ERROR: Could not find certificate ${cert}"
+    exit 1
+  fi
   echo "Revoking ${cert}"
-  if [ -z "${CA_REVOKE_CERT}" ]; then
+  if [[ -z "${CA_REVOKE_CERT}" ]]; then
     echo " + ERROR: Certificate authority doesn't allow certificate revocation." >&2
     exit 1
   fi

--- a/test.sh
+++ b/test.sh
@@ -163,9 +163,10 @@ _CHECK_ERRORLOG
 # Revoke certificate using certificate key
 _TEST "Revoking certificate..."
 ./letsencrypt.sh --revoke "certs/${TMP_URL}/cert.pem" --privkey "certs/${TMP_URL}/privkey.pem" > tmplog 2> errorlog
-_CHECK_LOG "Revoking certs/${TMP_URL}/cert.pem"
+REAL_CERT="$(readlink -n "certs/${TMP_URL}/cert.pem")"
+_CHECK_LOG "Revoking certs/${TMP_URL}/${REAL_CERT}"
 _CHECK_LOG "SUCCESS"
-_CHECK_FILE "certs/${TMP_URL}/cert.pem-revoked"
+_CHECK_FILE "certs/${TMP_URL}/${REAL_CERT}-revoked"
 _CHECK_ERRORLOG
 
 # All done


### PR DESCRIPTION
revoke: follow symlink and use real certificate filename so we move the file and not the cert.pem symlink
revoke: check if the given cert file exists, otherwise show error message and abort