### PR TITLE
fix: --domain/-d is a parameter and not a command!

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -570,7 +570,6 @@ while getopts ":hcer:d:xf:p:" option; do
       # PARAM_Usage: --domain (-d) domain.tld
       # PARAM_Description: Use specified domain name instead of domains.txt, use multiple times for certificate with SAN names
       check_parameters "${OPTARG:-}"
-      set_command sign_domains
       if [[ -z "${PARAM_DOMAIN:-}" ]]; then
         PARAM_DOMAIN="${OPTARG}"
       else

--- a/test.sh
+++ b/test.sh
@@ -114,7 +114,7 @@ _CHECK_ERRORLOG
 # Temporarily move config out of the way and try signing certificate by using temporary config location
 _TEST "Try signing using temporary config location and with domain as command line parameter"
 mv config.sh tmp_config.sh
-./letsencrypt.sh --domain "${TMP_URL}" -f tmp_config.sh > tmplog 2> errorlog
+./letsencrypt.sh --cron --domain "${TMP_URL}" -f tmp_config.sh > tmplog 2> errorlog
 _CHECK_LOG "Generating private key"
 _CHECK_LOG "Requesting challenge for ${TMP_URL}"
 _CHECK_LOG "Challenge is valid!"


### PR DESCRIPTION
$ ./letsencrypt.sh --domain test1.com --domain test2.com -c
Only one command can be executed at a time.
See help (-h) for more information.

This is obviously wrong. Fixed it.