### PR TITLE
add support for dns-01 challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Parameters:
  --force (-x)                     force renew of certificate even if it is longer valid than value in RENEW_DAYS
  --config (-f) path/to/config.sh  Use specified config file
  --privkey (-p) path/to/key.pem   Use specified private key instead of account key (useful for revocation)
+ --challenge (-t) http-01|dns-01  Which challenge should be used? Currently http-01 and dns-01 are supported
+ --hook (-k) path/to/hook.sh      Use specified script for hooks
 ```
 
 ### domains.txt

--- a/config.sh.example
+++ b/config.sh.example
@@ -19,6 +19,9 @@
 # Path to license agreement (default: https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf)
 #LICENSE="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
 
+# Which challenge should be used? Currently http-01 and dns-01 are supported
+#CHALLENGETYPE="http-01"
+
 # Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
 #BASEDIR=$SCRIPTDIR
 

--- a/hook-dns-01.sh.example
+++ b/hook-dns-01.sh.example
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+#
+# Example how to deploy a DNS challange using nsupdate
+#
+
+set -e
+set -u
+set -o pipefail
+umask 077
+
+updatefile="$(mktemp)"
+
+NSUPDATE="nsupdate -k /path/to/Kdnsupdatekey.private"
+done="no"
+
+if [[ "$1" = "deploy_challenge" ]]; then
+    printf "update add _acme-challenge.%s. 300 in TXT \"%s\"\n\n" "${2}" "${4}" > "${updatefile}"
+    $NSUPDATE "${updatefile}"
+    done="yes"
+fi
+
+if [[ "$1" = "clean_challenge" ]]; then
+    printf "update delete _acme-challenge.%s. 300 in TXT \"%s\"\n\n" "${2}" "${4}" > "${updatefile}"
+    $NSUPDATE "${updatefile}"
+    done="yes"
+fi
+
+if [[ "${1}" = "deploy_cert" ]]; then
+    # do nothing for now
+    done="yes"
+fi
+
+rm -f "${updatefile}"
+
+if [[ ! "${done}" = "yes" ]]; then
+    echo Unkown hook "${1}"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This adds support for the new dns-01 challenge!

ATTENTION: This challenge is currently only available in staging, see: https://community.letsencrypt.org/t/dns-challenge-is-in-staging/8322

I added a example script on how to deploy a DNS challenge using nsupdate. This should be easy to port to other APIs/services.

I am uncertain if "urlbase64" is the correct way in this case or if this should be a "base64 -w0".

See also: https://tools.ietf.org/html/draft-ietf-acme-acme-01#section-7.5