### PR TITLE
Add cleanup command to delete old files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Commands:
  --revoke (-r) path/to/cert.pem   Revoke specified certificate
  --help (-h)                      Show help text
  --env (-e)                       Output configuration variables for use in other scripts
+ --cleanup (-gc)                  Remove old and not used files in certs directory
 
 Parameters:
  --domain (-d) domain.tld         Use specified domain name(s) instead of domains.txt entry (one certificate!)


### PR DESCRIPTION
Since the script keeps all the old certificates as a backup, the folders can get messy after a while. So I thought, a cleanup command would be useful. When there are a lot of different domains, there would be a lot of files to delete manually, so this command helps by checking, which certificates are used and deletes the other ones.

I was thinking about how to implement it, and I think an automated or implicit cleanup would be against the thought of having backups in case of trouble. So I came up with this extra command, so the cleanup can be started explicitly, when the certificates are working fine.

I was thinking about only deleting expired certificates, but first I wanted to start with this idea, so we can discuss on this basis.