### PR TITLE
Remove home path from config.sh.example

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -5,7 +5,6 @@
 #                                                      #
 # This file is looked for in the following locations:  #
 # $SCRIPTDIR/config.sh (next to this script)           #
-# ${HOME}/.letsencrypt.sh/config.sh (in user home)     #
 # /usr/local/etc/letsencrypt.sh/config.sh              #
 # /etc/letsencrypt.sh/config.sh                        #
 # ${PWD}/config.sh (in current working-directory)      #


### PR DESCRIPTION
The `~/.letsencrypt.sh/config.sh` path is not checked anymore since ff11639 (#67). This removes it from the `config.sh.example` as it might confuse users.