### PR TITLE
Add ability to sign "arbitrary" CSRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Other dependencies are: curl, sed, grep, mktemp (all found on almost any system,
 
 Current features:
 - Signing of a list of domains
+- Signing of a CSR
 - Renewal if a certificate is about to expire or SAN (subdomains) changed
 - Certificate revocation
 
@@ -25,6 +26,7 @@ Default command: help
 
 Commands:
  --cron (-c)                      Sign/renew non-existant/changed/expiring certificates.
+ --signcsr (-s) path/to/csr.pem   Sign a given CSR, output CRT on stdout (advanced usage)
  --revoke (-r) path/to/cert.pem   Revoke specified certificate
  --help (-h)                      Show help text
  --env (-e)                       Output configuration variables for use in other scripts

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -526,6 +526,25 @@ command_sign_domains() {
   exit 0
 }
 
+# Usage: --signcsr (-s) path/to/csr.pem
+# Description: Sign a given CSR, output CRT on stdout (advanced usage)
+command_sign_csr() {
+  # redirect stdout to stderr
+  # leave stdout over at fd 3 to output the cert
+  exec 3>&1 1>&2
+
+  init_system
+
+  csrfile="${1}"
+  if [ ! -r "${csrfile}" ]; then
+    _exiterr "Could not read certificate signing request ${csrfile}"
+  fi
+
+  sign_csr "$(< "${csrfile}" )"
+
+  exit 0
+}
+
 # Usage: --revoke (-r) path/to/cert.pem
 # Description: Revoke specified certificate
 command_revoke() {
@@ -622,6 +641,13 @@ main() {
         set_command sign_domains
         ;;
 
+      --signcsr|-s)
+        shift 1
+        set_command sign_csr
+        check_parameters "${1:-}"
+        PARAM_CSR="${1}"
+        ;;
+
       --revoke|-r)
         shift 1
         set_command revoke
@@ -702,6 +728,7 @@ main() {
   case "${COMMAND}" in
     env) command_env;;
     sign_domains) command_sign_domains;;
+    sign_csr) command_sign_csr "${PARAM_CSR}";;
     revoke) command_revoke "${PARAM_REVOKECERT}";;
     *) command_help; exit 1;;
   esac

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -257,6 +257,36 @@ signed_request() {
   http_request post "${1}" "${data}"
 }
 
+# Extracts all subject names from a CSR
+# Outputs either the CN, or the SANs, one per line
+extract_altnames() {
+  csr="${1}" # the CSR itself (not a file)
+
+  if ! <<<"${csr}" openssl req -verify -noout 2>/dev/null; then
+    _exiterr "Certificate signing request isn't valid"
+  fi
+
+  reqtext="$( <<<"${csr}" openssl req -noout -text )"
+  if <<<"$reqtext" grep -q '^[[:space:]]*X509v3 Subject Alternative Name:[[:space:]]*$'; then
+    # SANs used, extract these
+    altnames="$( <<<"${reqtext}" grep -A1 '^[[:space:]]*X509v3 Subject Alternative Name:[[:space:]]*$' | tail -n1 )"
+    # split to one per line:
+    altnames="$( <<<"${altnames}" _sed -e 's/^[[:space:]]*//; s/, /\'$'\n''/' )"
+    # we can only get DNS: ones signed
+    if [ -n "$( <<<"${altnames}" grep -v '^DNS:' )" ]; then
+      _exiterr "Certificate signing request contains non-DNS Subject Alternative Names"
+    fi
+    # strip away the DNS: prefix
+    altnames="$( <<<"${altnames}" _sed -e 's/^DNS://' )"
+    echo "$altnames"
+
+  else
+    # No SANs, extract CN
+    altnames="$( <<<"${reqtext}" grep '^[[:space:]]*Subject:' | _sed -e 's/.* CN=([^ /,]*).*/\1/' )"
+    echo "$altnames"
+  fi
+}
+
 # Create certificate for domain(s) and outputs it FD 3
 sign_csr() {
   csr="${1}" # the CSR itself (not a file)
@@ -269,6 +299,9 @@ sign_csr() {
 
   shift 1 || true
   altnames="${*:-}"
+  if [ -z "$altnames" ]; then
+    altnames="$( extract_altnames "$csr" )"
+  fi
 
   if [[ -z "${CA_NEW_AUTHZ}" ]] || [[ -z "${CA_NEW_CERT}" ]]; then
     _exiterr "Certificate authority doesn't allow certificate signing"


### PR DESCRIPTION
I was looking for a Let's Encrypt client to integrate in to an existing automation tool. Your `letsencrypt.sh` implementation came closest. However, it still does too much.

This pull requests splits out the core functionality (sign a CSR) from the nice-to-have features (generate a CSR from the `domains.txt` file), and exposes this functionality from the command line.

The newly added `--signcsr` command does exactly what its name implies: it extracts the domain names from the CSR (SANs or CN), requests and executes the challenge for each one, requests the CRT, and outputs that to stdout (normal output is redirected to stderr for this command).