### PR TITLE
Fix possibly broken syntax highlighting

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -54,7 +54,7 @@ load_config() {
   WELLKNOWN="${BASEDIR}/.acme-challenges"
   PRIVATE_KEY_RENEW="no"
   KEY_ALGO=rsa
-  OPENSSL_CNF="$(openssl version -d | cut -d'"' -f2)/openssl.cnf"
+  OPENSSL_CNF="$(openssl version -d | cut -d\" -f2)/openssl.cnf"
   CONTACT_EMAIL=
   LOCKFILE="${BASEDIR}/lock"
 


### PR DESCRIPTION
The pattern
```
 VAR="$(cmd '"')"
```
breaks syntax highlighting in some editors (e.g. gedit or jedit) due to
the tripple double quotes.