### PR TITLE
Add conf.d support

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ########################################################
-# This is the config file for letsencrypt.sh           #
+# This is the main config file for letsencrypt.sh      #
 #                                                      #
 # This file is looked for in the following locations:  #
 # $SCRIPTDIR/config.sh (next to this script)           #
@@ -20,6 +20,12 @@
 
 # Which challenge should be used? Currently http-01 and dns-01 are supported
 #CHALLENGETYPE="http-01"
+
+# Path to a directory containing additional config files, allowing to override
+# the defaults found in the main configuration file. Additional config files
+# in this directory needs to be named with a '.sh' ending.
+# default: <unset>
+#CONFIG_D=
 
 # Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
 #BASEDIR=$SCRIPTDIR

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -47,6 +47,7 @@ load_config() {
   CA="https://acme-v01.api.letsencrypt.org/directory"
   LICENSE="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
   CHALLENGETYPE="http-01"
+  CONFIG_D=
   HOOK=
   RENEW_DAYS="30"
   PRIVATE_KEY="${BASEDIR}/private_key.pem"
@@ -60,15 +61,33 @@ load_config() {
 
   if [[ -z "${CONFIG:-}" ]]; then
     echo "#" >&2
-    echo "# !! WARNING !! No config file found, using default config!" >&2
+    echo "# !! WARNING !! No main config file found, using default config!" >&2
     echo "#" >&2
   elif [[ -e "${CONFIG}" ]]; then
-    echo "# INFO: Using config file ${CONFIG}"
+    echo "# INFO: Using main config file ${CONFIG}"
     BASEDIR="$(dirname "${CONFIG}")"
     # shellcheck disable=SC1090
     . "${CONFIG}"
   else
     _exiterr "Specified config file doesn't exist."
+  fi
+
+  if [[ -n "${CONFIG_D}" ]]; then
+    if [[ ! -d "${CONFIG_D}" ]]; then
+      _exiterr "The path ${CONFIG_D} specified for CONFIG_D does not point to a directory." >&2
+    fi
+
+    for check_config_d in ${CONFIG_D}/*.sh; do
+      if [[ ! -e "${check_config_d}" ]]; then
+        echo "# !! WARNING !! Extra configuration directory ${CONFIG_D} exists, but no configuration found in it." >&2
+        break
+      elif [[ -f "${check_config_d}" ]] && [[ -r "${check_config_d}" ]]; then
+        echo "# INFO: Using additional config file ${check_config_d}"
+        . ${check_config_d}
+      else
+        _exiterr "Specified additional config ${check_config_d} is not readable or not a file at all." >&2
+      fi
+   done
   fi
 
   # Remove slash from end of BASEDIR. Mostly for cleaner outputs, doesn't change functionality.


### PR DESCRIPTION
This PR adds support for a new config variable CONFIG_D in the main
configuration file. Setting a path to a directoy for CONFIG_D advises
letsencrypt.sh to source any additional files found in the specified
CONFIG_D directory, that have a '.sh' ending.
By default CONFIG_D is not set, meaning letsencrypt.sh does not source any
additional configuration files.

> ### Background
> From the perspective of a Linux distribution, letsencrypt.sh should be shipped
> with a default configuration located at /etc/letsencrypt.sh/config.sh. Neither
> the user nor other packages should need to mangle this default configuration.
> Instead configuration changes should go into separate files.
