### PR TITLE
check if curl is able to reach letsencrypt via http and https.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -39,6 +39,22 @@ check_dependencies() {
   if [[ ! "${retcode}" = "0" ]] && [[ ! "${retcode}" = "2" ]]; then
     _exiterr "This script requires curl."
   fi
+
+  # is curl be able to reach letsencrypt.org via http and https (maybe firewall, dns or proxy problem)
+  set +e
+  curl -k https://letsencrypt.org > /dev/null 2>&1
+  retcode="$?"
+  set -e
+  if [[ ! "${retcode}" = "0" ]] && [[ ! "${retcode}" = "2" ]]; then
+    _exiterr "curl requires a https_proxy."
+  fi
+  set +e
+  curl http://letsencrypt.org > /dev/null 2>&1
+  retcode="$?"
+  set -e
+  if [[ ! "${retcode}" = "0" ]] && [[ ! "${retcode}" = "2" ]]; then
+    _exiterr "curl requires a http_proxy."
+  fi
 }
 
 # Setup default config values, search for and load configuration files


### PR DESCRIPTION
I had the problem that http_proxy env var was not set. Because of set -e curl terminated with != 0 and the whole script terminated without error message.
So I've added 2 checks in check_dependencies() if curl is able to reach letsencrypt.org via http and https.
Another problem could be the firewall (port 80 or 443 blocked), dns or routing.