### PR TITLE
Skip non-folder entries on cleanup.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -675,6 +675,9 @@ command_cleanup() {
 
   # Loop over all certificate directories
   for certdir in "${BASEDIR}/certs/"*; do
+    # Skip if entry is not a folder
+    [[ -d "${certdir}" ]] || continue
+
     # Get certificate name
     certname="$(basename "${certdir}")"
 


### PR DESCRIPTION
I had symlinks to some files in my `certs` folder, for each of them a folder was created in the `archive` directory. This pull request skips all non-folder entries in `certs` when running cleanup.