### PR TITLE
Handle case where no files to cleanup exist.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -701,6 +701,9 @@ command_cleanup() {
 
       # Loop over all files of this type
       for file in "${certdir}/${filebase}-"*".${fileext}"; do
+        # Handle case where no files match the wildcard
+        [[ -f "${file}" ]] || break
+
         # Check if current file is in use, if unused move to archive directory
         filename="$(basename "${file}")"
         if [[ ! "${filename}" = "${current}" ]]; then


### PR DESCRIPTION
This fixes cases where `*.foo` expands to the string `*.foo` instead of an empty string if no matching files exist.

I know this is a problem with my setup, but it would be nice if letsencrypt.sh could handle such cases gracefully ;-)

Error without the change (I have a `chain.pem` in `customfolder`):
```
Moving unused file to archive directory: customfolder/chain-*.pem
mv: cannot stat '/path/to/customfolder/chain-*.pem': No such file or directory
```
