### PR TITLE
Use /usr/bin/env bash shebang

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########################################################
 # This is the main config file for letsencrypt.sh      #

--- a/hook.sh.example
+++ b/hook.sh.example
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function deploy_challenge {
     local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Fail early
 set -eu -o pipefail


### PR DESCRIPTION
On FreeBSD bash is installed in `/usr/local/bin`; this patch alters the shebang to use `/usr/bin/env bash` instead, to ensure that the shell scripts work on (particularly) the *BSDs as well.