### PR TITLE
Pass intermediate cert to hook script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 private_key.pem
 domains.txt
 config.sh
+hook.sh
 certs/*
 archive/*
 .acme-challenges/*

--- a/hook.sh.example
+++ b/hook.sh.example
@@ -32,7 +32,7 @@ function clean_challenge {
 }
 
 function deploy_cert {
-    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" CHAINFILE="${4}"
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
 
     # This hook is called once for each certificate that has been
     # produced. Here you might, for instance, copy your new certificates
@@ -46,8 +46,10 @@ function deploy_cert {
     #   The path of the file containing the private key.
     # - CERTFILE
     #   The path of the file containing the signed certificate.
-    # - CHAINFILE
+    # - FULLCHAINFILE
     #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
 }
 
 HANDLER=$1; shift; $HANDLER $@

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -533,7 +533,7 @@ sign_domain() {
   ln -sf "cert-${timestamp}.pem" "${BASEDIR}/certs/${domain}/cert.pem"
 
   # Wait for hook script to clean the challenge and to deploy cert if used
-  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${BASEDIR}/certs/${domain}/privkey.pem" "${BASEDIR}/certs/${domain}/cert.pem" "${BASEDIR}/certs/${domain}/fullchain.pem" <&4 >&5 2>&6
+  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${BASEDIR}/certs/${domain}/privkey.pem" "${BASEDIR}/certs/${domain}/cert.pem" "${BASEDIR}/certs/${domain}/fullchain.pem" "${BASEDIR}/certs/${domain}/chain.pem" <&4 >&5 2>&6
 
   unset challenge_token
   echo " + Done!"


### PR DESCRIPTION
Some services need the `chain.pem` file for configuration, simply passing that path to the hook script is probably cleaner than getting the path from the `fullchain.pem` file by doing `CHAINFILE=${4/full/}`.