### PR TITLE
Add support for --keep-going in cron mode

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -712,7 +712,12 @@ command_sign_domains() {
     fi
 
     # shellcheck disable=SC2086
-    sign_domain ${line}
+    if [[ "${PARAM_KEEP_GOING:-}" = "yes" ]]; then
+      sign_domain ${line} &
+      wait $! || true
+    else
+      sign_domain ${line}
+    fi
   done
 
   # remove temporary domains.txt file if used
@@ -941,6 +946,12 @@ main() {
          fi
         ;;
 
+
+      # PARAM_Usage: --keep-going (-g)
+      # PARAM_Description: Keep going after encountering an error while creating/renewing multiple certificates in cron mode
+      --keep-going|-g)
+        PARAM_KEEP_GOING="yes"
+        ;;
 
       # PARAM_Usage: --force (-x)
       # PARAM_Description: Force renew of certificate even if it is longer valid than value in RENEW_DAYS

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -319,6 +319,8 @@ http_request() {
     echo >&2
     echo "Details:" >&2
     cat "${tempcont}" >&2
+    echo >&2
+    echo >&2
     rm -f "${tempcont}"
 
     # Wait for hook script to clean the challenge if used


### PR DESCRIPTION
Just as the title says.

The strange construct with wait is because with a regular ( ) subshell set -e does not propagate, causing the script to misbehave.

Also adds some newlines to the error function, to make the output more readable in case of errors in keep-going mode.