### PR TITLE
Add hook for unchanged certificates.

### DIFF
--- a/hook.sh.example
+++ b/hook.sh.example
@@ -52,4 +52,24 @@ function deploy_cert {
     #   The path of the file containing the intermediate certificate(s).
 }
 
+function unchanged_cert {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+
+    # This hook is called once for each certificate that is still
+    # valid and therefore wasn't reissued.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+}
+
 HANDLER=$1; shift; $HANDLER $@

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -598,7 +598,9 @@ command_sign_domains() {
         if [[ "${force_renew}" = "yes" ]]; then
           echo "Ignoring because renew was forced!"
         else
-          echo "Skipping!"
+          # Certificate-Names unchanged and cert is still valid
+          echo "Skipping renew! Calling unchanged-hook."
+          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${BASEDIR}/certs/${domain}/privkey.pem" "${BASEDIR}/certs/${domain}/cert.pem" "${BASEDIR}/certs/${domain}/fullchain.pem" "${BASEDIR}/certs/${domain}/chain.pem"
           continue
         fi
       else

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -599,7 +599,7 @@ command_sign_domains() {
           echo "Ignoring because renew was forced!"
         else
           # Certificate-Names unchanged and cert is still valid
-          echo "Skipping renew! Calling unchanged-hook."
+          echo "Skipping renew!"
           [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${BASEDIR}/certs/${domain}/privkey.pem" "${BASEDIR}/certs/${domain}/cert.pem" "${BASEDIR}/certs/${domain}/fullchain.pem" "${BASEDIR}/certs/${domain}/chain.pem"
           continue
         fi

--- a/test.sh
+++ b/test.sh
@@ -153,7 +153,7 @@ _TEST "Run in cron mode again, this time with domain in domains.txt, should find
 echo "${TMP_URL} ${TMP2_URL} ${TMP3_URL}" >> domains.txt
 ./letsencrypt.sh --cron > tmplog 2> errorlog || _FAIL "Script execution failed"
 _CHECK_LOG "Checking domain name(s) of existing cert... unchanged."
-_CHECK_LOG "Skipping!"
+_CHECK_LOG "Skipping renew"
 _CHECK_ERRORLOG
 
 # Run in cron mode one last time, with domain in domains.txt and force-resign (should find certificate, resign anyway, and not generate private key)


### PR DESCRIPTION
In my scenario, where I automate certificate-issuance through the `letsencrypt.sh`-client, I need to also have a hook for all certificates, of which the domains haven't changed and which are still valid.

I tried to integrate this functionality, as I think more people could benefit from this feature.
As far as I am concerned, it works as expected.

I'd greatly appreciate if you could merge this pull-request.

Thanks,

Leon