### PR TITLE
Make temp files identifiable and remove unnecessary eval

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -772,7 +772,7 @@ main() {
     fi
   }
 
-  [[ -z "${@}" ]] && eval set -- "--help"
+  [[ -z "${@}" ]] && set -- "--help"
 
   while (( ${#} )); do
     case "${1}" in


### PR DESCRIPTION
This pr adds a wrapper for `mktemp` to make sure it's always called it with a template. This way any temporary files are identifiable for the administrator since they are now named `letsencrypt.sh.XXXXXX` where `XXXXXX` is unique.

This pr also removes an `eval` which is not necessary.