### PR TITLE
Keep registration information as json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 private_key.pem
+private_key.json
 domains.txt
 config.sh
 hook.sh

--- a/config.sh.example
+++ b/config.sh.example
@@ -36,6 +36,9 @@
 # Location of private account key (default: $BASEDIR/private_key.pem)
 #PRIVATE_KEY="${BASEDIR}/private_key.pem"
 
+# Location of private account registration information (default: $BASEDIR/private_key.json)
+#PRIVATE_KEY_JSON="${BASEDIR}/private_key.json"
+
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"
 

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -60,6 +60,7 @@ load_config() {
   HOOK_CHAIN="no"
   RENEW_DAYS="30"
   PRIVATE_KEY=
+  PRIVATE_KEY_JSON=
   KEYSIZE="4096"
   WELLKNOWN=
   PRIVATE_KEY_RENEW="no"
@@ -106,6 +107,7 @@ load_config() {
   [[ -d "${BASEDIR}" ]] || _exiterr "BASEDIR does not exist: ${BASEDIR}"
 
   [[ -z "${PRIVATE_KEY}" ]] && PRIVATE_KEY="${BASEDIR}/private_key.pem"
+  [[ -z "${PRIVATE_KEY_JSON}" ]] && PRIVATE_KEY_JSON="${BASEDIR}/private_key.json"
   [[ -z "${WELLKNOWN}" ]] && WELLKNOWN="${BASEDIR}/.acme-challenges"
   [[ -z "${LOCKFILE}" ]] && LOCKFILE="${BASEDIR}/lock"
 
@@ -171,9 +173,9 @@ init_system() {
     [[ ! -z "${CA_NEW_REG}" ]] || _exiterr "Certificate authority doesn't allow registrations."
     # If an email for the contact has been provided then adding it to the registration request
     if [[ -n "${CONTACT_EMAIL}" ]]; then
-      signed_request "${CA_NEW_REG}" '{"resource": "new-reg", "contact":["mailto:'"${CONTACT_EMAIL}"'"], "agreement": "'"$LICENSE"'"}' > /dev/null
+      signed_request "${CA_NEW_REG}" '{"resource": "new-reg", "contact":["mailto:'"${CONTACT_EMAIL}"'"], "agreement": "'"$LICENSE"'"}' > "${PRIVATE_KEY_JSON}"
     else
-      signed_request "${CA_NEW_REG}" '{"resource": "new-reg", "agreement": "'"$LICENSE"'"}' > /dev/null
+      signed_request "${CA_NEW_REG}" '{"resource": "new-reg", "agreement": "'"$LICENSE"'"}' > "${PRIVATE_KEY_JSON}"
     fi
   fi
 


### PR DESCRIPTION
In some cases you need your registration id,
for example if you want to request a rate limit exception.
So keep the new-reg output on disk.