### PR TITLE
Configuration stubs and validation hooks for use on QNAP devices

### DIFF
--- a/docs/qnap/README.md
+++ b/docs/qnap/README.md
@@ -1,0 +1,46 @@
+# letsencrypt.sh for QNAP units
+
+## Common Installation
+
+Alter the config.sh to enable a configuration directory
+```
+CONFIG_D=${SCRIPTDIR}/config.d
+```
+
+Place the following two files in the config.d/ directory
+  * `qnap_cabundle.sh` - installs CA certificates so that curl validation works
+  * `qnap_mktemp.sh` - implements the full mktemp functionality with qnap's stub
+
+Place the DNS names for your QNAP unit on a single line in `domains.txt`
+```
+echo "qnap.example.com nas.example.com" > domains.txt
+```
+
+## DNS Validation
+
+Recommended: This validation requires you to make changes to your DNS.
+It does not require exposing your QNAP device to Internet traffic,
+therefore it is the higher-security approach.
+
+The script will provide instructions on what changes to make to DNS.
+It is up to you to make these changes. You'll need to rerun this script
+and revalidate every 90 days to renew your certificate.
+
+### Installation
+
+Place the following file in the hook/ directory
+  * `qnap-dns01-stunnel-install.sh`
+
+## HTTP Validation
+
+If you are willing to expose your QNAP to internet traffic for validation purposes,
+you can enable HTTP validation. This is not recommended for security reasons, but
+does allow for automatic renewal by running the script from cron.
+
+### Installation
+
+Place the following file in the config.d/ directory
+  * `qnap_web_validation.sh`
+
+Place the following file in the hook/ directory
+  * `qnap-http01-stunnel-install.sh`

--- a/docs/qnap/qnap-dns01-stunnel-install.sh
+++ b/docs/qnap/qnap-dns01-stunnel-install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# This hook is called once for every domain that needs to be
+# validated, including any alternative names you may have listed.
+function deploy_challenge {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    echo "Create the following DNS record:"
+    echo "_acme-challenge.${DOMAIN}.      300 IN TXT \"${TOKEN_VALUE}\""
+    echo ""
+    echo "Hit [ENTER] when DNS entries have been created"
+    read -s -r -e < /dev/tty
+
+    # Now check DNS results
+    RESULT=$(dig +short _acme-challenge.${DOMAIN}. TXT 2> /dev/null | sed -e 's/^"//' | sed -e 's/"$//')
+    if [[ $RESULT != $TOKEN_VALUE ]]; then
+      echo ""
+      echo "Either dig command is not installed, or the expected result is not available in DNS yet."
+      echo "Please fix and retest manually using this command on another host:"
+      echo "    dig _acme-challenge.${DOMAIN}. TXT"
+      echo ""
+      echo "Hit [ENTER] when you see the correct value returned."
+      read -s -r -e < /dev/tty
+    fi
+}
+
+function clean_challenge {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+
+    echo ""
+    echo "You may now remove DNS records which start with _acme-challenge and have this value: ${TOKEN_VALUE}"
+    echo ""
+}
+
+# This hook is called once for each certificate that has been
+# produced. Here you might, for instance, copy your new certificates
+# to service-specific locations and reload the service.
+function deploy_cert {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+    cp /etc/stunnel/stunnel.pem /etc/stunnel/stunnel.pem-$(date +%Y%m%d)
+    cat $KEYFILE $FULLCHAINFILE > /etc/stunnel/stunnel.pem
+    /etc/init.d/stunnel.sh restart
+}
+
+# This hook is called once for each certificate that is still
+# valid and therefore wasn't reissued.
+function unchanged_cert {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+}
+
+HANDLER=$1; shift; $HANDLER $@

--- a/docs/qnap/qnap-http01-stunnel-install.sh
+++ b/docs/qnap/qnap-http01-stunnel-install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This hook is called once for every domain that needs to be
+# validated, including any alternative names you may have listed.
+function deploy_challenge {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+}
+
+function clean_challenge {
+    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+}
+
+# This hook is called once for each certificate that has been
+# produced. Here you might, for instance, copy your new certificates
+# to service-specific locations and reload the service.
+function deploy_cert {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+    cp /etc/stunnel/stunnel.pem /etc/stunnel/stunnel.pem-$(date +%Y%m%d)
+    cat $KEYFILE $FULLCHAINFILE > /etc/stunnel/stunnel.pem
+    /etc/init.d/stunnel.sh restart
+}
+
+# This hook is called once for each certificate that is still
+# valid and therefore wasn't reissued.
+function unchanged_cert {
+    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"
+}
+
+HANDLER=$1; shift; $HANDLER $@

--- a/docs/qnap/qnap_cabundle.sh
+++ b/docs/qnap/qnap_cabundle.sh
@@ -1,0 +1,10 @@
+if [[ -f /etc/ssl/certs/ca-certificates.crt ]]
+then
+    export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+else
+    if [[ ! -f /etc/ssl/certs/cabundle.pem ]]
+    then
+        wget --quiet --no-check-certificate -O /etc/ssl/certs/cabundle.pem https://curl.haxx.se/ca/cacert.pem
+    fi
+    export SSL_CERT_FILE=/etc/ssl/certs/cabundle.pem
+fi

--- a/docs/qnap/qnap_mktemp.sh
+++ b/docs/qnap/qnap_mktemp.sh
@@ -1,0 +1,30 @@
+function mktemp() {
+    LOCATION=""
+    PASS_OPTIONS=""
+    RM_TEMPFILE=0
+    while [[ $1 == -* ]]
+    do
+        case $1 in
+        -t)
+            LOCATION="${TMPDIR:-/tmp}/"
+            ;;
+        -u)
+            RM_TEMPFILE=1
+            ;;
+        -d)
+            PASS_OPTIONS="-d"
+            ;;
+        *)
+            # Ignore unsupported option
+            ;;
+        esac
+        shift
+    done
+
+    TEMPFILE=$(/bin/mktemp ${PASS_OPTIONS} ${LOCATION}$*)
+    echo $TEMPFILE
+
+    if [[ $RM_TEMPFILE -eq 1 ]]; then
+        rm $TEMPFILE
+    fi
+}

--- a/docs/qnap/qnap_web_validation.sh
+++ b/docs/qnap/qnap_web_validation.sh
@@ -1,0 +1,3 @@
+WEBROOT=/share/$(/sbin/getcfg SHARE_DEF defWeb -d Qweb -f /etc/config/def_share.info)
+WELLKNOWN=${WEBROOT}/.well-known/acme-challenges
+mkdir -p ${WELLKNOWN}


### PR DESCRIPTION
These files can be used as described in the README for using letsencrypt.sh on QNAP devices. Tested and working for both HTTP and DNS validation.