### PR TITLE
Adding --testCA for testing on Let's Encrypt staging API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ For getting started I recommend taking a look at [docs/domains_txt.md](docs/doma
 
 Generally you want to set up your WELLKNOWN path first, and then fill in domains.txt.
 
-**Please note that you should use the staging URL when experimenting with this script to not hit letsencrypts rate limits.** See [docs/staging.md](docs/staging.md).
+**Please note that you should use the staging URL when experimenting with this script to not hit letsencrypts rate limits.** See [docs/staging.md](docs/staging.md). In short, apply `letsencrypt.sh` parameter `--testCA` for any command.
+
+Good start steps
+
+* put your domain name to `domains.txt` - [docs/domains_txt.md](docs/domains_txt.md)
+* config your wellknown path - [docs/domains_txt.md](docs/domains_txt.md)
+* show your configuration `./letsencrypt.sh --env --testCA`
+* test generatin dummy certificate `./letsencrypt.sh -c --testCA` - [docs/staging.md](docs/staging.md)
 
 If you have any problems take a look at our [Troubleshooting](docs/troubleshooting.md) guide.
 

--- a/docs/examples/config.sh.example
+++ b/docs/examples/config.sh.example
@@ -15,6 +15,10 @@
 # Path to certificate authority (default: https://acme-v01.api.letsencrypt.org/directory)
 #CA="https://acme-v01.api.letsencrypt.org/directory"
 
+# Path to certificate authority (default:"https://acme-staging.api.letsencrypt.org/directory")
+# for usage with --testCA - perfect for testing configuration or hooks
+#TEST_CA="https://acme-staging.api.letsencrypt.org/directory"
+
 # Path to license agreement (default: https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf)
 #LICENSE="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
 
@@ -38,6 +42,13 @@
 
 # Location of private account registration information (default: $BASEDIR/private_key.json)
 #ACCOUNT_KEY_JSON="${BASEDIR}/private_key.json"
+
+# Filenames of testing CA private account key and registration information
+#   files are stored in the same directory as a ACCOUNT_KEY and a ACCOUNT_KEY_JSON
+# (default: testCA_private_key.pem)
+#TEST_ACCOUNT_KEY_FILE="testCA_private_key.pem"
+# (default: testCA_private_key.json)
+#TEST_ACCOUNT_KEY_JSON_FILE="testCA_private_key.json"
 
 # Default keysize for private keys (default: 4096)
 #KEYSIZE="4096"

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,15 +1,34 @@
-# Staging
+# Staging and testing
 
 Let’s Encrypt has stringent rate limits in place during the public beta period.
 
 If you start testing using the production endpoint (which is the default),
 you will quickly hit these limits and find yourself locked out.
 
-To avoid this, please set the CA property to the Let’s Encrypt staging server URL in your `config.sh` file:
+For souch cases Let’s Encrypt provides staging server URL for testing and developement.
+
+To use it, please apply `letsencrypt.sh` parameter `--testCA` for any command.
 
 ```bash
-CA="https://acme-staging.api.letsencrypt.org/directory"
+$ letsencryph configuration
+#
+# !! WARNING !! No main config file found, using default config!
+#
+declare -- CA="https://acme-staging.api.letsencrypt.org/directory"
+declare -- LICENSE="https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
+declare -- CHALLENGETYPE="http-01"
+declare -- HOOK=""
+declare -- HOOK_CHAIN="no"
+declare -- RENEW_DAYS="30"
+declare -- ACCOUNT_KEY="/opt/letsencrypt.sh/testCA_private_key.pem"
+declare -- ACCOUNT_KEY_JSON="/opt/letsencrypt.sh/testCA_private_key.json"
+declare -- KEYSIZE="4096"
+declare -- WELLKNOWN="/opt/letsencrypt.sh/.acme-challenges"
+declare -- PRIVATE_KEY_RENEW="yes"
+declare -- OPENSSL_CNF="/usr/lib/ssl/openssl.cnf"
+declare -- CONTACT_EMAIL=""
+declare -- LOCKFILE="/opt/letsencrypt.sh/lock"
 ```
 
 Please keep in mind that at the time of writing this letsencrypt.sh doesn't have support for registration management,
-so if you change CA you'll have to move your `private_key.pem` (and, if you care, `private_key.json`) out of the way.
+so if you use `--testCA` you'll have second pair of private key and json: `testCA_private_key.pem`, `testCA_private_key.json`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,14 +2,9 @@
 
 Generally if the following information doesn't provide a solution to your problem please take a look at existing issues (search for keywords) before creating a new one.
 
-## "No registration exists matching provided key"
+## Avoid tests on production-CA
 
-You probably changed from staging-CA to production-CA (or the other way).
-
-Currently letsencrypt.sh doesn't detect a missing registration on the selected CA,
-the current workaround is to move `private_key.pem` (and, if you care, `private_key.json`) out of the way so the scripts generates and registers a new one.
-
-This will hopefully be fixed in the future.
+Use --testCA for generating dummy certs and checking your configuration is correct, before using production-CA
 
 ## "Provided agreement URL [LICENSE1] does not match current agreement URL [LICENSE2]"
 
@@ -36,3 +31,15 @@ If you are using http validation make sure that the path you have configured wit
 To test this create a file (e.g. `test.txt`) in that directory and try opening it with your browser: `http://example.org/.well-known/acme-challenge/test.txt`.
 
 If you get any error you'll have to fix your webserver configuration.
+
+## "No registration exists matching provided key"
+
+This should be soleved by using --testCA, but if used staging-CA with older version of `letsencrypt.sh`, this solves your problem.
+
+You probably changed from staging-CA to production-CA (or the other way).
+
+Currently letsencrypt.sh doesn't detect a missing registration on the selected CA,
+the current workaround is to move `private_key.pem` (and, if you care, `private_key.json`) out of the way so the scripts generates and registers a new one.
+
+This will hopefully be fixed in the future.
+

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -77,6 +77,11 @@ load_config() {
   CONTACT_EMAIL=
   LOCKFILE=
 
+  # Overrides for --testCA - default values
+  TEST_CA="https://acme-staging.api.letsencrypt.org/directory"
+  TEST_ACCOUNT_KEY_FILE="testCA_private_key.pem"
+  TEST_ACCOUNT_KEY_JSON_FILE="testCA_private_key.json"
+
   if [[ -z "${CONFIG:-}" ]]; then
     echo "#" >&2
     echo "# !! WARNING !! No main config file found, using default config!" >&2
@@ -129,6 +134,14 @@ load_config() {
    _exiterr "Challenge type dns-01 needs a hook script for deployment... can not continue."
   fi
   [[ "${KEY_ALGO}" =~ ^(rsa|prime256v1|secp384r1)$ ]] || _exiterr "Unknown public key algorithm ${KEY_ALGO}... can not continue."
+
+  # force test variables in case of --testCA
+  if [[ -n "${PARAM_TEST_CA:-}" ]]
+  then
+    CA="${TEST_CA}"
+    ACCOUNT_KEY="$(dirname ${ACCOUNT_KEY})/${TEST_ACCOUNT_KEY_FILE}"
+    ACCOUNT_KEY_JSON="$(dirname ${ACCOUNT_KEY_JSON})/${TEST_ACCOUNT_KEY_JSON_FILE}"
+  fi
 }
 
 # Initialize system
@@ -880,6 +893,12 @@ main() {
         shift 1
         check_parameters "${1:-}"
         PARAM_KEY_ALGO="${1}"
+        ;;
+
+      # PARAM_Usage: --testCA
+      # PARAM_Description: Use testing CA - perfect for checking configuration or hooks
+      --testCA)
+        PARAM_TEST_CA="y"
         ;;
 
       *)


### PR DESCRIPTION
with --testCA parameter, you can use staging API with all commands without moving any files or changing configuration.

Solves #92 with minimal changes to code and configuration.

