### PR TITLE
Fix issues on 2016-05-18. Remove new lines from json response.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -378,7 +378,7 @@ sign_csr() {
     echo " + Requesting challenge for ${altname}..."
     response="$(signed_request "${CA_NEW_AUTHZ}" '{"resource": "new-authz", "identifier": {"type": "dns", "value": "'"${altname}"'"}}')"
 
-    challenges="$(printf '%s\n' "${response}" | sed -n 's/.*\("challenges":[^\[]*\[[^]]*]\).*/\1/p')"
+    challenges="$(printf '%s\n' "${response}" | sed ':a;N;$!ba;s/\n//g' | sed -n 's/.*\("challenges":[^\[]*\[[^]]*]\).*/\1/p')"
     repl=$'\n''{' # fix syntax highlighting in Vim
     challenge="$(printf "%s" "${challenges//\{/${repl}}" | grep \""${CHALLENGETYPE}"\")"
     challenge_token="$(printf '%s' "${challenge}" | get_json_string_value token | _sed 's/[^A-Za-z0-9_\-]/_/g')"


### PR DESCRIPTION
I found out the lets'encrypt API returned pretty json with new lines which break the sed parsing. 

This patch just remove the new lines from the json.