### PR TITLE
Make certificate output location configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Parameters:
  --privkey (-p) path/to/key.pem   Use specified private key instead of account key (useful for revocation)
  --config (-f) path/to/config     Use specified config file
  --hook (-k) path/to/hook.sh      Use specified script for hooks
+ --out (-o) certs/directory       Output certificates into the specified directory
  --challenge (-t) http-01|dns-01  Which challenge should be used? Currently http-01 and dns-01 are supported
  --algo (-a) rsa|prime256v1|secp384r1 Which public key algorithm should be used? Supported: rsa, prime256v1 and secp384r1
 ```

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -31,6 +31,9 @@
 # File containing the list of domains to request certificates for (default: $BASEDIR/domains.txt)
 #DOMAINS_TXT="${BASEDIR}/domains.txt"
 
+# Output directory for generated certificates
+#CERTDIR="${BASEDIR}/certs"
+
 # Output directory for challenge-tokens to be served by webserver or deployed in HOOK (default: $BASEDIR/.acme-challenges)
 #WELLKNOWN="${BASEDIR}/.acme-challenges"
 


### PR DESCRIPTION
Particularly useful if you want to set up dual certificates, you can set the config files to output into separate directories rather than using separate base directories for each. e.g. `CERTDIR="${BASEDIR}/certs/rsa"` and `CERTDIR="${BASEDIR}/certs/ecdsa"`