### PR TITLE
fix mktemp arg quoting

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -25,7 +25,7 @@ BASEDIR="${SCRIPTDIR}"
 # Create (identifiable) temporary files
 _mktemp() {
   # shellcheck disable=SC2068
-  mktemp ${@:-} "${TMPDIR:-/tmp}/letsencrypt.sh-XXXXXX"
+  mktemp ${1:+"$@"} "${TMPDIR:-/tmp}/letsencrypt.sh-XXXXXX"
 }
 
 # Check for script dependencies


### PR DESCRIPTION
fix for #178 broke quoting (75985c6a), arguments with spaces get exploded to different args

altho i don't have old enough bash to test with (#178 did not indicate what version he had or was it even bash), i'm pretty sure this change is safe