### PR TITLE
Fix domain name check from certificate.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -697,7 +697,7 @@ command_sign_domains() {
     if [[ -e "${cert}" ]]; then
       printf " + Checking domain name(s) of existing cert..."
 
-      certnames="$(openssl x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
+      certnames="$(openssl x509 -in "${cert}" -text -noout | grep Subject: | sed -r 's/CN=//g' | tr -d ' ' | cut -f2 -d':' | cut -f1 -d'/')"
       givennames="$(echo "${domain}" "${morenames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
 
       if [[ "${certnames}" = "${givennames}" ]]; then


### PR DESCRIPTION
It looks like Let's Encrypt changed the way they generate certificates early this morning. There are no longer "DNS" lines, breaking the check to extract the cert name.

We (@colans & I) just switched to looking in the CN. We haven't tested with alt names yet, but will be shortly.