### PR TITLE
Added option to select IP version of name to address resolution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ This file contains a log of major changes in letsencrypt.sh
 - Added option to add CSR-flag indicating OCSP stapling to be mandatory
 - Initial support for configuration on per-certificate base
 - Support for per-CA account keys and custom config for output cert directory, license, etc.
+- Added option to select IP version of name to address resolution
 
 ## Fixed
 - letsencrypt.sh no longer stores account keys from invalid registrations

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Commands:
  --env (-e)                       Output configuration variables for use in other scripts
 
 Parameters:
+ --ipv4 (-4)                      Resolve names to IPv4 addresses only
+ --ipv6 (-6)                      Resolve names to IPv6 addresses only
  --domain (-d) domain.tld         Use specified domain name(s) instead of domains.txt entry (one certificate!)
  --force (-x)                     Force renew of certificate even if it is longer valid than value in RENEW_DAYS
  --ocsp                           Sets option in CSR indicating OCSP stapling to be mandatory

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -10,6 +10,11 @@
 # Default values of this config are in comments        #
 ########################################################
 
+# Resolve names to addresses of IP version only. (curl)
+# supported values: 4, 6
+# default: <unset>
+#IP_VERSION=
+
 # Path to certificate authority (default: https://acme-v01.api.letsencrypt.org/directory)
 #CA="https://acme-v01.api.letsencrypt.org/directory"
 

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -58,6 +58,7 @@ store_configvars() {
   __HOOK_CHAIN="${HOOK_CHAIN}"
   __OPENSSL_CNF="${OPENSSL_CNF}"
   __RENEW_DAYS="${RENEW_DAYS}"
+  __IP_VERSION="${IP_VERSION}"
 }
 
 reset_configvars() {
@@ -71,6 +72,7 @@ reset_configvars() {
   HOOK_CHAIN="${__HOOK_CHAIN}"
   OPENSSL_CNF="${__OPENSSL_CNF}"
   RENEW_DAYS="${__RENEW_DAYS}"
+  IP_VERSION="${__IP_VERSION}"
 }
 
 # verify configuration values
@@ -83,6 +85,9 @@ verify_config() {
     _exiterr "WELLKNOWN directory doesn't exist, please create ${WELLKNOWN} and set appropriate permissions."
   fi
   [[ "${KEY_ALGO}" =~ ^(rsa|prime256v1|secp384r1)$ ]] || _exiterr "Unknown public key algorithm ${KEY_ALGO}... can not continue."
+  if [[ -n "${IP_VERSION}" ]]; then
+    [[ "${IP_VERSION}" = "4" || "${IP_VERSION}" = "6" ]] || _exiterr "Unknown IP version ${IP_VERSION}... can not continue."
+  fi
 }
 
 # Setup default config values, search for and load configuration files
@@ -117,6 +122,7 @@ load_config() {
   CONTACT_EMAIL=
   LOCKFILE=
   OCSP_MUST_STAPLE="no"
+  IP_VERSION=
 
   if [[ -z "${CONFIG:-}" ]]; then
     echo "#" >&2
@@ -182,6 +188,7 @@ load_config() {
   [[ -n "${PARAM_CHALLENGETYPE:-}" ]] && CHALLENGETYPE="${PARAM_CHALLENGETYPE}"
   [[ -n "${PARAM_KEY_ALGO:-}" ]] && KEY_ALGO="${PARAM_KEY_ALGO}"
   [[ -n "${PARAM_OCSP_MUST_STAPLE:-}" ]] && OCSP_MUST_STAPLE="${PARAM_OCSP_MUST_STAPLE}"
+  [[ -n "${PARAM_IP_VERSION:-}" ]] && IP_VERSION="${PARAM_IP_VERSION}"
 
   verify_config
   store_configvars
@@ -315,15 +322,19 @@ _openssl() {
 http_request() {
   tempcont="$(_mktemp)"
 
+  if [[ -n "${IP_VERSION:-}" ]]; then
+      ip_version="-${IP_VERSION}"
+  fi
+
   set +e
   if [[ "${1}" = "head" ]]; then
-    statuscode="$(curl -s -w "%{http_code}" -o "${tempcont}" "${2}" -I)"
+    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}" -I)"
     curlret="${?}"
   elif [[ "${1}" = "get" ]]; then
-    statuscode="$(curl -s -w "%{http_code}" -o "${tempcont}" "${2}")"
+    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}")"
     curlret="${?}"
   elif [[ "${1}" = "post" ]]; then
-    statuscode="$(curl -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
+    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
     curlret="${?}"
   else
     set -e
@@ -948,6 +959,18 @@ main() {
 
       --cleanup|-gc)
         set_command cleanup
+        ;;
+
+      # PARAM_Usage: --ipv4 (-4)
+      # PARAM_Description: Resolve names to IPv4 addresses only
+      --ipv4|-4)
+        PARAM_IP_VERSION="4"
+        ;;
+
+      # PARAM_Usage: --ipv6 (-6)
+      # PARAM_Description: Resolve names to IPv6 addresses only
+      --ipv6|-6)
+        PARAM_IP_VERSION="6"
         ;;
 
       # PARAM_Usage: --domain (-d) domain.tld


### PR DESCRIPTION
Issue is:
Name resolves to bunch of an IPv4 and IPv6 addresses, but IPv6 is unreachable from network.
Hence --ipv4 is passed to curl.