### PR TITLE
Make umask a bit less paranoid

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -9,7 +9,7 @@ set -e
 set -u
 set -o pipefail
 [[ -n "${ZSH_VERSION:-}" ]] && set -o SH_WORD_SPLIT && set +o FUNCTION_ARGZERO
-umask 077 # paranoid umask, we're creating private keys
+umask 027 # paranoid umask, we're creating private keys
 
 # Find directory in which this script is stored by traversing all symbolic links
 SOURCE="${0}"


### PR DESCRIPTION
While I understand the idea behind the 077 umask, I think its kinda problematic: Most of my service are running as their own user, and some of them seem to try to read the file after dropping the privileges, which is not possible with the files having 600 as access mask. I don't want to run all these application as lets-encrypt user or as root, and I think the most sensitive solution is to set the files group-readable.

Since on most modern Distributions a user belongs to his own distinct group this change is not a dangerous escalation, but this way I can add the users which needs to access the private keys to the lets-encrypt usergroup.