### PR TITLE
ECDSA is supported since February 10, 2016

### DIFF
--- a/docs/ecc.md
+++ b/docs/ecc.md
@@ -1,5 +1,4 @@
 ### Elliptic Curve Cryptography (ECC)
 
 This script also supports certificates with Elliptic Curve public keys!
-Be aware that at the moment this is not available on the production servers from letsencrypt.
-Please read https://community.letsencrypt.org/t/ecdsa-testing-on-staging/8809/ for the current state of ECC support.
+Simply set the `KEY_ALGO` variable in one of the config files.


### PR DESCRIPTION
Let's Encrypt will however sign all ECDSA certs with an RSA intermediate certificate.
https://letsencrypt.org/upcoming-features/