### PR TITLE
Retry invalid challenge responses,  set number of retries to NUMBER

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Parameters:
  --ipv4 (-4)                      Resolve names to IPv4 addresses only
  --ipv6 (-6)                      Resolve names to IPv6 addresses only
  --domain (-d) domain.tld         Use specified domain name(s) instead of domains.txt entry (one certificate!)
+ --retries (-r) NUMBER            Retry invalid challenge responses,  set number of retries to NUMBER
  --keep-going (-g)                Keep going after encountering an error while creating/renewing multiple certificates in cron mode
  --force (-x)                     Force renew of certificate even if it is longer valid than value in RENEW_DAYS
  --no-lock (-n)                   Don't use lockfile (potentially dangerous!)


### PR DESCRIPTION
Coded to your coding standards, shellchecked

This will allow for the challenge to be retied for X times when it fails (returns  invalid)

Allot of our servers are via cdn/load-balancers and they do not always sync quick enough, so will fail the first X attempts. 

This also allows your script to have resiliency with bad connections/timeouts.

````
letsencrypt.sh --cron --force --retries 10

Processing test.extremeshok.com
 + Checking domain name(s) of existing cert... unchanged.
 + Checking expire date of existing cert...
 + Valid till Nov 19 22:26:00 2016 GMT (Longer than 30 days). Ignoring because renew was forced!
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting challenge for test.extremeshok.com...
 + Responding to challenge for test.extremeshok.com...attempt: 1
 + Invalid
 + Requesting challenge for test.extremeshok.com...
 + Responding to challenge for test.extremeshok.com...attempt: 2
 + Challenge is valid!
 + Requesting certificate...
 + Checking certificate...
 + Done!
 + Creating fullchain.pem...
 + Done!
````