### PR TITLE
Fix hook based challenges if the same domain appears twice or more

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1080,23 +1080,19 @@ sign_csr() {
   echo " + ${num_pending_challenges} pending challenge(s)"
 
   # Deploy challenge tokens
-  if [[ ${num_pending_challenges} -ne 0 ]]; then
+  if [[ ${num_pending_challenges} -ne 0 ]] && [[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" = "yes" ]]; then
     echo " + Deploying challenge tokens..."
-    if [[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" = "yes" ]]; then
-      "${HOOK}" "deploy_challenge" ${deploy_args[@]} || _exiterr 'deploy_challenge hook returned with non-zero exit code'
-    elif [[ -n "${HOOK}" ]]; then
-      # Run hook script to deploy the challenge token
-      local idx=0
-      while [ ${idx} -lt ${num_pending_challenges} ]; do
-        "${HOOK}" "deploy_challenge" ${deploy_args[${idx}]} || _exiterr 'deploy_challenge hook returned with non-zero exit code'
-        idx=$((idx+1))
-      done
-    fi
+    "${HOOK}" "deploy_challenge" ${deploy_args[@]} || _exiterr 'deploy_challenge hook returned with non-zero exit code'
   fi
 
   # Validate pending challenges
   local idx=0
   while [ ${idx} -lt ${num_pending_challenges} ]; do
+    if [[ -n "${HOOK}" ]] && [[ ! "${HOOK_CHAIN}" = "yes" ]]; then
+      echo " + Deploying challenge token for ${challenge_names[${idx}]}..."
+      "${HOOK}" "deploy_challenge" ${deploy_args[${idx}]} || _exiterr 'deploy_challenge hook returned with non-zero exit code'
+    fi
+
     echo " + Responding to challenge for ${challenge_names[${idx}]} authorization..."
 
     # Ask the acme-server to verify our challenge and wait until it is no longer pending


### PR DESCRIPTION
When two or more domains are present in the challenge, all the hook calls happen before asking the acme server to verify the challenge. This is breaking configurations that need to verify the same domain more than once, e.g. dns based challenges with `example.com`. and `*.example.com`. In this case, `example.com` will be verified twice, maybe with distinct tokens, leading to the second configuration overwriting the first one before the challenge verification.

This update moves the hook call into the while-loop that asks the acme server to verify the challenge, so a second configuration will only happen after the first one has being verified.