### PR TITLE
egrep is deprecated

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -125,8 +125,7 @@ jsonsh() {
       GREP='grep -Eao'
     fi
 
-    # shellcheck disable=SC2196
-    if echo "test string" | egrep -ao "test" >/dev/null 2>&1
+    if echo "test string" | grep -Eao "test" >/dev/null 2>&1
     then
       ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
       CHAR='[^[:cntrl:]"\\]'


### PR DESCRIPTION
egrep has been deprecated since 2007 and warns it's obsolete since:
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1