### PR TITLE
Ignore output of 'openssl req -verify'.

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1011,7 +1011,7 @@ signed_request() {
 extract_altnames() {
   csr="${1}" # the CSR itself (not a file)
 
-  if ! <<<"${csr}" "${OPENSSL}" req -verify -noout 2>/dev/null; then
+  if ! <<<"${csr}" "${OPENSSL}" req -verify -noout >/dev/null 2>&1; then
     _exiterr "Certificate signing request isn't valid"
   fi
 


### PR DESCRIPTION
Newer versions of openssl seem to send the verify outout to stdout instead of stderr in the past. Ignore that output when retrieving altnames.