### PR TITLE
Implement ARI support when checking certificate renewal

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -659,6 +659,7 @@ init_system() {
     CA_NEW_ORDER="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newOrder)" &&
     CA_NEW_NONCE="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newNonce)" &&
     CA_NEW_ACCOUNT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value newAccount)" &&
+    CA_RENEWAL_INFO="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value renewalInfo || true)" &&
     CA_TERMS="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value -p '"meta","termsOfService"')" &&
     CA_REQUIRES_EAB="$(printf "%s" "${CA_DIRECTORY}" | get_json_bool_value -p '"meta","externalAccountRequired"' || echo false)" &&
     CA_REVOKE_CERT="$(printf "%s" "${CA_DIRECTORY}" | get_json_string_value revokeCert)" ||
@@ -902,6 +903,15 @@ _sed() {
     sed -r "${@}"
   else
     sed -E "${@}"
+  fi
+}
+
+# Different date versions act very differently.
+rfc3339date2unix() {
+  if [[ "${OSTYPE}" = "Linux" || "${OSTYPE:0:5}" = "MINGW" ]]; then
+    date -d "$1" "+%s"
+  else
+    date -j -f "%Y-%m-%dT%H:%M:%S%z" "${1/%Z/+0000}" "+%s"
   fi
 }
 
@@ -1998,6 +2008,42 @@ command_sign_domains() {
         echo " + Configured names: ${givennames}"
         echo " + Forcing renew."
         force_renew="yes"
+      fi
+    fi
+
+    if [[ -e "${cert}" && "${force_renew}" = "no" && -n "${CA_RENEWAL_INFO}" ]]; then
+      printf " + Checking renewal info for existing cert..."
+
+      authkeyid="$("${OPENSSL}" x509 -in "${cert}" -noout -ext authorityKeyIdentifier | sed -n '2{s/keyid://;s/[[:space:]:]//g;p}' | hex2bin | urlbase64)"
+      serial="$("${OPENSSL}" x509 -in "${cert}" -noout -serial | cut -d= -f2)"
+      encserial="$("${OPENSSL}" asn1parse -genstr "INT:0x${serial}" -noout -out - | tail -c +3 | urlbase64)"
+
+      ari_response="$(http_request get "${CA_RENEWAL_INFO}/${authkeyid}.${encserial}" | jsonsh)"
+      window_start="$(printf "%s" "${ari_response}" | get_json_string_value -p '"suggestedWindow","start"')"
+      window_end="$(printf "%s" "${ari_response}" | get_json_string_value -p '"suggestedWindow","end"')"
+      expl_url="$(printf "%s" "${ari_response}" | get_json_string_value explanationURL)"
+
+      if [[ -n "${window_start}" && -n "${window_end}" ]]; then
+        window_start_unix="$(rfc3339date2unix "${window_start}")"
+        window_end_unix="$(rfc3339date2unix "${window_end}")"
+
+        # Assume we run once a day, so substract one day as per ari rfc.
+        # Add 1 second to window size to avoid possible div by zero.
+        renewal_datetime_unix="$(( ((RANDOM<<15)|RANDOM) % (${window_end_unix} - ${window_start_unix} + 1) + ${window_start_unix} - 86400 ))"
+
+        if [[ "${renewal_datetime_unix}" -le "$(date "+%s")" ]]; then
+          echo " renewal requested!"
+          force_renew="yes"
+        else
+          echo " no renewal requested."
+        fi
+        echo "  + Renewal window: ${window_start} to ${window_end}"
+      else
+        echo " unknown."
+      fi
+
+      if [[ -n "${expl_url}" ]]; then
+        echo "  + See also: ${expl_url}"
       fi
     fi
 

--- a/dehydrated
+++ b/dehydrated
@@ -1159,6 +1159,7 @@ get_last_cn() {
 # Create certificate for domain(s) and outputs it FD 3
 sign_csr() {
   csrfile="${1}" # path to CSR file
+  replaces_cert_identifier="${2}" # optional cert identifier as per rfc9773 section 4.1
 
   if { true >&3; } 2>/dev/null; then
     : # fd 3 looks OK
@@ -1166,7 +1167,7 @@ sign_csr() {
     _exiterr "sign_csr: FD 3 not open"
   fi
 
-  shift 1 || true
+  shift 2 || true
   export altnames="${*}"
 
   if [[ ${API} -eq 1 ]]; then
@@ -1204,6 +1205,9 @@ sign_csr() {
     local order_payload='{"identifiers": '"${challenge_identifiers}"
     if [[ -n "${ACME_PROFILE}" ]]; then
       order_payload="${order_payload}"',"profile":"'"${ACME_PROFILE}"'"'
+    fi
+    if [[ -n "${replaces_cert_identifier}" ]]; then
+      order_payload="${order_payload}"',"replaces":"'"${replaces_cert_identifier}"'"'
     fi
     order_payload="${order_payload}"'}'
     order_location="$(signed_request "${CA_NEW_ORDER}" "${order_payload}" 4>&1 | grep -i ^Location: | cut -d':' -f2- | tr -d ' \t\r\n')"
@@ -1567,6 +1571,8 @@ generate_alpn_certificate() {
 sign_domain() {
   local certdir="${1}"
   shift
+  local replaces_cert_identifier="${1}"
+  shift
   timestamp="${1}"
   shift
   domain="${1}"
@@ -1653,7 +1659,7 @@ sign_domain() {
 
   crt_path="${certdir}/cert-${timestamp}.pem"
   # shellcheck disable=SC2086
-  sign_csr "${certdir}/cert-${timestamp}.csr" ${altnames} 3>"${crt_path}"
+  sign_csr "${certdir}/cert-${timestamp}.csr" "${replaces_cert_identifier}" ${altnames} 3>"${crt_path}"
 
   # Create fullchain.pem
   echo " + Creating fullchain.pem..."
@@ -2011,14 +2017,18 @@ command_sign_domains() {
       fi
     fi
 
-    if [[ -e "${cert}" && "${force_renew}" = "no" && -n "${CA_RENEWAL_INFO}" ]]; then
-      printf " + Checking renewal info for existing cert..."
-
+    local cert_identifier=""
+    if [[ -e "${cert}" && -n "${CA_RENEWAL_INFO}" ]]; then
       authkeyid="$("${OPENSSL}" x509 -in "${cert}" -noout -ext authorityKeyIdentifier | sed -n '2{s/keyid://;s/[[:space:]:]//g;p}' | hex2bin | urlbase64)"
       serial="$("${OPENSSL}" x509 -in "${cert}" -noout -serial | cut -d= -f2)"
       encserial="$("${OPENSSL}" asn1parse -genstr "INT:0x${serial}" -noout -out - | tail -c +3 | urlbase64)"
+      cert_identifier="${authkeyid}.${encserial}"
+    fi
 
-      ari_response="$(http_request get "${CA_RENEWAL_INFO}/${authkeyid}.${encserial}" | jsonsh)"
+    if [[ -e "${cert}" && "${force_renew}" = "no" && -n "${CA_RENEWAL_INFO}" ]]; then
+      printf " + Checking renewal info for existing cert..."
+
+      ari_response="$(http_request get "${CA_RENEWAL_INFO}/${cert_identifier}" | jsonsh)"
       window_start="$(printf "%s" "${ari_response}" | get_json_string_value -p '"suggestedWindow","start"')"
       window_end="$(printf "%s" "${ari_response}" | get_json_string_value -p '"suggestedWindow","end"')"
       expl_url="$(printf "%s" "${ari_response}" | get_json_string_value explanationURL)"
@@ -2081,11 +2091,11 @@ command_sign_domains() {
       # shellcheck disable=SC2086
       if [[ "${KEEP_GOING:-}" = "yes" ]]; then
         skip_exit_hook=yes
-        sign_domain "${certdir}" "${timestamp}" "${domain}" ${morenames} &
+        sign_domain "${certdir}" "${cert_identifier}" "${timestamp}" "${domain}" ${morenames} &
         wait $! || exit_with_errorcode=1
         skip_exit_hook=no
       else
-        sign_domain "${certdir}" "${timestamp}" "${domain}" ${morenames}
+        sign_domain "${certdir}" "${cert_identifier}" "${timestamp}" "${domain}" ${morenames}
       fi
     fi
 
@@ -2135,7 +2145,7 @@ command_sign_csr() {
   # gen cert
   certfile="$(_mktemp)"
   # shellcheck disable=SC2086
-  sign_csr "${csrfile}" ${altnames} 3> "${certfile}"
+  sign_csr "${csrfile}" "" ${altnames} 3> "${certfile}"
 
   # print cert
   echo "# CERT #" >&3


### PR DESCRIPTION
This implements ACME ARI according to https://letsencrypt.org/2024/04/25/guide-to-integrating-ari-into-existing-acme-clients/

Since we can't trigger a run at some point in the future, this is implemented according to the alternative approach.
It assumes the script is run once per day, so if the randomized renewal time is within the next 24h, a renewal will be triggered.

I did not test this on OSX/non-coreutils systems, so I do not know if the date-magic for it works. But I also didn't find any good portable way to deal with those rfc3339 dates.