### PR TITLE
Replace `hexdump` but the more available `od` command

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -260,7 +260,7 @@ _mktemp() {
 # Check for script dependencies
 check_dependencies() {
   # look for required binaries
-  for binary in grep mktemp diff sed awk curl cut head tail hexdump; do
+  for binary in grep mktemp diff sed awk curl cut head tail od; do
     bin_path="$(command -v "${binary}" 2>/dev/null)" || _exiterr "This script requires ${binary}."
     [[ -x "${bin_path}" ]] || _exiterr "${binary} found in PATH but it's not executable"
   done
@@ -907,7 +907,7 @@ hex2bin() {
 
 # Convert binary data to hex string
 bin2hex() {
-  hexdump -v -e '/1 "%02x"'
+  od -An -tx1 | tr -d ' \n'
 }
 
 # OpenSSL writes to stderr/stdout even when there are no errors. So just


### PR DESCRIPTION
`od` is specified by POSIX and is probably more readily available. On Linux systems, it typically comes with the `coreutils` package.

This should avoid needing to pull the `bsdextrautils` package on Debian systems at least (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1088049).