### PR TITLE
Allow to override user agent with CURL_OPTS

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -939,14 +939,14 @@ http_request() {
   set +e
   # shellcheck disable=SC2086
   if [[ "${1}" = "head" ]]; then
-    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" -s -w "%{http_code}" -o "${tempcont}" -H 'Cache-Control: no-cache' "${2}" -I)"
+    statuscode="$(curl ${ip_version:-} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" -H 'Cache-Control: no-cache' "${2}" -I)"
     curlret="${?}"
     touch "${tempheaders}"
   elif [[ "${1}" = "get" ]]; then
-    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" -L -s -w "%{http_code}" -o "${tempcont}" -D "${tempheaders}" -H 'Cache-Control: no-cache' "${2}")"
+    statuscode="$(curl ${ip_version:-} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" ${CURL_OPTS} -L -s -w "%{http_code}" -o "${tempcont}" -D "${tempheaders}" -H 'Cache-Control: no-cache' "${2}")"
     curlret="${?}"
   elif [[ "${1}" = "post" ]]; then
-    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" -s -w "%{http_code}" -o "${tempcont}" "${2}" -D "${tempheaders}" -H 'Cache-Control: no-cache' -H 'Content-Type: application/jose+json' -d "${3}")"
+    statuscode="$(curl ${ip_version:-} -A "dehydrated/${VERSION} curl/${CURL_VERSION}" ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}" -D "${tempheaders}" -H 'Cache-Control: no-cache' -H 'Content-Type: application/jose+json' -d "${3}")"
     curlret="${?}"
   else
     set -e


### PR DESCRIPTION
Apparently, there is at least one CA out there where the WAF blocks requests using "dehydrated" in the User-Agent. I could try to bypass this with setting a different user-agent in CURL_OPTS, if the evaluation order was different, since curl man page states:
```
If --user-agent is provided several times, the last set value is used.
```

Context:
```
raphael ~ $ curl "https://acme-api.actalis.com/acme/directory"
{"newAuthz": "https://acme-api.actalis.com/acme/new-authz", "newNonce": "https://acme-api.actalis.com/acme/newnonce", "newAccount": "https://acme-api.actalis.com/acme/newaccount", "newOrder": "https://acme-api.actalis.com/acme/neworders", "revokeCert": "https://acme-api.actalis.com/acme/revokecert", "keyChange": "https://acme-api.actalis.com/acme/key-change", "renewalInfo": "https://acme-api.actalis.com/acme/renewal-info", "meta": {"home": "https://www.actalis.com", "author": "Actalis S.p.A. <info@actalis.com>", "name": "acme-server", "version": "1.1.3", "termsOfService": "https://www.actalis.it/acme/terms", "externalAccountRequired": true}, "a4f79e25fe3041b5b73d7b6308f8b94b": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417"}
raphael ~ $ curl -A "dehydrated/1" "https://acme-api.actalis.com/acme/directory"
…<h3>Web Page Blocked!</h3><div class="notice"><p>The page cannot be displayed. Please contact the administrator for additional information.</p><p>URL: acme-api.actalis.com/acme/directory<br /><br/>Client IP: xx.xx.xx.xx<br/>Attack ID: 20000051<br/>Message ID: 001083935386</p><p></p></div></div></body></html>
```